### PR TITLE
Replace unsafePerformIO with runST, bonus speed! (Fixes #15)

### DIFF
--- a/src/SuperRecord.hs
+++ b/src/SuperRecord.hs
@@ -83,7 +83,7 @@ import GHCJS.Marshal
 import qualified Data.JSString as JSS
 import qualified JavaScript.Object.Internal as JS
 import System.IO.Unsafe (unsafePerformIO)
-#endif
+#else
 import GHC.ST ( ST(..) , runST)
 #endif
 

--- a/src/SuperRecord.hs
+++ b/src/SuperRecord.hs
@@ -73,7 +73,6 @@ import Data.Constraint
 import Data.Proxy
 import GHC.Base (Int(..), Any)
 import GHC.Generics
-import GHC.ST ( ST(..) , runST)
 import GHC.Prim
 import GHC.TypeLits
 import qualified Control.Monad.State as S
@@ -83,6 +82,10 @@ import qualified Data.Text as T
 import GHCJS.Marshal
 import qualified Data.JSString as JSS
 import qualified JavaScript.Object.Internal as JS
+import GHC.IO ( IO (..) )
+import System.IO.Unsafe (unsafePerformIO)
+#endif
+import GHC.ST ( ST(..) , runST)
 #endif
 
 -- | Sort a list of fields using merge sort, alias to 'FieldListSort'

--- a/src/SuperRecord.hs
+++ b/src/SuperRecord.hs
@@ -138,8 +138,10 @@ instance RecNfData lts lts => NFData (Rec lts) where
     rnf = recNfData (Proxy :: Proxy lts)
 
 -- Hack needed because $! doesn't have the same special treatment $ does to work with ST yet
+#ifndef JS_RECORD
 runST' :: (forall s. ST s a) -> a
 runST' !s = runST s
+#endif
 
 -- | An empty record
 rnil :: Rec '[]

--- a/src/SuperRecord.hs
+++ b/src/SuperRecord.hs
@@ -82,7 +82,6 @@ import qualified Data.Text as T
 import GHCJS.Marshal
 import qualified Data.JSString as JSS
 import qualified JavaScript.Object.Internal as JS
-import GHC.IO ( IO (..) )
 import System.IO.Unsafe (unsafePerformIO)
 #endif
 import GHC.ST ( ST(..) , runST)


### PR DESCRIPTION
Replace all uses of `unsafePerformIO` wth `runST`. Unexpectedly this has resulted in some serious performance improvements, with some benchmarks now running *4x* faster according to criterion. Purity for the win again! I'm a little skeptical about these results so would love someone else to confirm them - specifically the benchmarks `set nested/superrecord`, `get set/superrecord`, `set rec/superrecord` and `dummy list/superrecord` are now _much_ faster. This might be because GHC no longer has to be careful about having nested IO actions, but that's just speculation.