### PR TITLE
Export 'unsafeRNil' and 'unsafeRCons'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.5.1.0
+
+* Exported `unsafeRNil` and `unsafeRCons`.
+
 # 0.5.0.1
 
 * GHC 8.6 pre-release compatibility (h/t @galenhuntington)

--- a/src/SuperRecord.hs
+++ b/src/SuperRecord.hs
@@ -61,6 +61,9 @@ module SuperRecord
     , RecAll
     , KeyDoesNotExist
     , Sort
+      -- * Unsafe operations
+    , unsafeRNil
+    , unsafeRCons
     )
 where
 

--- a/src/SuperRecord.hs
+++ b/src/SuperRecord.hs
@@ -152,23 +152,23 @@ runST' !s = runST s
 
 -- | An empty record
 rnil :: Rec '[]
-rnil = unsafeRnil 0
+rnil = unsafeRNil 0
 {-# INLINE rnil #-}
 
 -- | An empty record with an initial size for the record
-unsafeRnil :: Int -> Rec '[]
+unsafeRNil :: Int -> Rec '[]
 #ifndef JS_RECORD
-unsafeRnil (I# n#) =
+unsafeRNil (I# n#) =
     runST' $ ST $ \s# ->
     case newSmallArray# n# (error "No Value") s# of
       (# s'#, arr# #) ->
           case unsafeFreezeSmallArray# arr# s'# of
             (# s''#, a# #) -> (# s''# , Rec a# #)
 #else
-unsafeRnil _ =
+unsafeRNil _ =
     unsafePerformIO $! Rec <$> JS.create
 #endif
-{-# INLINE unsafeRnil #-}
+{-# INLINE unsafeRNil #-}
 
 -- | Prepend a record entry to a record 'Rec'
 rcons ::
@@ -238,7 +238,7 @@ instance
              s'# -> recCopyInto pNext lts prxy tgt# s'#
 
 -- | Prepend a record entry to a record 'Rec'. Assumes that the record was created with
--- 'unsafeRnil' and still has enough free slots, mutates the original 'Rec' which should
+-- 'unsafeRNil' and still has enough free slots, mutates the original 'Rec' which should
 -- not be reused after
 unsafeRCons ::
     forall l t lts s.
@@ -674,7 +674,7 @@ class RecJsonParse (lts :: [*]) where
     recJsonParse :: Int -> Object -> Parser (Rec lts)
 
 instance RecJsonParse '[] where
-    recJsonParse initSize _ = pure (unsafeRnil initSize)
+    recJsonParse initSize _ = pure (unsafeRNil initSize)
 
 instance
     ( KnownSymbol l, FromJSON t, RecJsonParse lts

--- a/superrecord.cabal
+++ b/superrecord.cabal
@@ -1,5 +1,5 @@
 name:                superrecord
-version:             0.5.0.1
+version:             0.5.1.0
 synopsis:            Supercharged anonymous records
 description:         Anonymous records with various useful utilities
 homepage:            https://github.com/agrafix/superrecord#readme


### PR DESCRIPTION
I started implementing my own `RecJsonParse` for a different typeclass and found out that I couldn't do that in the same efficient way that the "official" `RecJsonParse` is implemented.