### PR TITLE
Change import for base-4.15 compatibility.

### DIFF
--- a/src/SuperRecord.hs
+++ b/src/SuperRecord.hs
@@ -78,7 +78,7 @@ import Data.Constraint
 import Data.Proxy
 import GHC.Base (Int(..), Any)
 import GHC.Generics
-import GHC.Prim
+import GHC.Exts
 import GHC.TypeLits
 import qualified Control.Monad.State as S
 import qualified Data.Text as T


### PR DESCRIPTION
`GHC.Prim` no longer exports `unsafeCoerce#`.  However, we can get everything we need from `GHC.Exts`.