### PR TITLE
Remove 'KeyDoesNotExist' check in 'unsafeRCons'

### DIFF
--- a/src/SuperRecord.hs
+++ b/src/SuperRecord.hs
@@ -239,12 +239,13 @@ instance
 
 -- | Prepend a record entry to a record 'Rec'. Assumes that the record was created with
 -- 'unsafeRNil' and still has enough free slots, mutates the original 'Rec' which should
--- not be reused after
+-- not be reused after.
+--
+-- Does /not/ check that the key being inserted doesn't clash.
 unsafeRCons ::
     forall l t lts s.
     ( RecSize lts ~ s
     , KnownNat s
-    , KeyDoesNotExist l lts
 #ifdef JS_RECORD
     , ToJSVal t
 #endif


### PR DESCRIPTION
I've been working through a situation which required me to build a record at runtime, and found I needed to remove the `KeyDoesNotExist` constraint in `unsafeRCons` to get it to work. As it's already an unsafe function, I would expect that making it slightly more unsafe shouldn't be a problem.    

However it would be nice to include some record construction function which automatically handles all the unsafe aspects:

  * setting the correct record size,
  * sorting the fields as necessary,
  * ensuring there are no duplicate fields.

I'm unsure of what type to give that function exactly. Something like:

```haskell
data Exists c where
  Exists :: c a => a -> Exists c

class Forall c kvs where
  forallSing :: ForallSing c kvs

data ForallSing c kvs where
  NilForall :: ForallSing c '[]
  ConsForall :: ( KnownSymbol k, c v ) => ForallSing c kvs -> ForallSing c ( ( k := v ) ': kvs )


withRecordFields :: forall c r. [ ( String, Exists c ) ] -> ( forall kvs. Forall c kvs => Record kvs -> r ) -> r
```

Here the `Forall` stuff is just whatever machinery is needed to provide type reflection (I'm unsure if there is a standard library that already provides these functions).   
It's reasonably straightforward to write `withRecordFields` using `unsafeRCons` and `unsafeRNil` **provided** that we remove the `KeyDoesNotExist` constraint; without that, satisfying the GHC constraint solver is somewhat irksome.