### PR TITLE
Generalize RecApply + associated refactors

### DIFF
--- a/src/SuperRecord.hs
+++ b/src/SuperRecord.hs
@@ -51,7 +51,7 @@ module SuperRecord
       -- * Machinery
     , Rec
     , RecCopy
-    , RecTyIdxH
+    , RecTy, RecTyIdxH
     , showRec, RecKeys(..), recKeys
     , recToValue, recToEncoding
     , recJsonParser, RecJsonParse(..)

--- a/src/SuperRecord.hs
+++ b/src/SuperRecord.hs
@@ -62,6 +62,7 @@ module SuperRecord
     , RecAll
     , KeyDoesNotExist
     , Sort
+    , ConstC, Tuple22C
       -- * Unsafe operations
     , unsafeRNil
     , unsafeRCons

--- a/src/SuperRecord.hs
+++ b/src/SuperRecord.hs
@@ -673,7 +673,11 @@ class UnsafeRecBuild (rts :: [*]) (lts :: [*]) c where
 instance ( RecSize rts ~ s, KnownNat s ) => UnsafeRecBuild rts '[] c where
     unsafeRecBuild _ = unsafeRNil ( fromIntegral $ natVal' ( proxy# :: Proxy# s ) )
 
-instance ( UnsafeRecBuild rts lts c, RecSize lts ~ s, KnownNat s, KnownSymbol l, c l t )
+instance ( UnsafeRecBuild rts lts c, RecSize lts ~ s, KnownNat s, KnownSymbol l, c l t
+#ifdef JS_RECORD
+         , ToJSVal t
+#endif
+         )
         => UnsafeRecBuild rts ( l := t ': lts ) c where
     unsafeRecBuild f = unsafeRCons @l @t @lts @s ( lbl := f lbl ( proxy# :: Proxy#t ) ) ( unsafeRecBuild @rts @lts @c f )
         where

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -46,7 +46,7 @@ r1 =
 r2 :: Record '["foo" := String]
 r2 = #foo := "He" & rnil
 
-polyFun :: Has "foo" lts String => Rec lts -> String
+polyFun :: Has lts "foo" String => Rec lts -> String
 polyFun = get #foo
 
 polyFun2 :: HasOf '["foo" := String, "bar" := Bool] lts => Rec lts -> String
@@ -57,7 +57,7 @@ rNested :: Record '["foo" := Record '["bar" := Int] ]
 rNested =
     #foo := (#bar := 213 & rnil) & rnil
 
-mtlAsk :: (MonadReader (Rec env) m, Has "id" env Int) => m Int
+mtlAsk :: (MonadReader (Rec env) m, Has env "id" Int) => m Int
 mtlAsk = asksR #id
 
 type BigFieldList =


### PR DESCRIPTION
  * Generalize `RecApply` to allow the type class instance to depend on the field label.
  * Change `Has` to a class newtype to allow partial application (this involved changing the order of arguments to facilitate the most common partial application).
  * Use `RecApply` to rewrite the `Eq` and `NFData` instances (obviating the need for custom type classes for those).
  * Use `RecApply` to implement a `Semigroup` instance.
  * Add a function for building a record given an overloaded constructor method, using it to write a `Monoid` instance.
  * Remove `KeyDoesNotAppear` constraint from `unsafeRCons` (#29).
  * Remove several redundant proxy arguments by enabling `AllowAmbiguousTypes`.