### PR TITLE
Complete support for GHC 9.0 & 9.2 as well as aeson 2.0

### DIFF
--- a/src/SuperRecord.hs
+++ b/src/SuperRecord.hs
@@ -86,7 +86,6 @@ import GHC.Generics
 import GHC.Exts
 import GHC.TypeLits
 import qualified Control.Monad.State as S
-import qualified Data.Text as T
 import Data.Semigroup as Sem (Semigroup(..))
 
 #ifdef JS_RECORD
@@ -97,6 +96,22 @@ import qualified JavaScript.Object.Internal as JS
 #else
 import GHC.ST ( ST(..) , runST)
 #endif
+
+#if MIN_VERSION_aeson(2, 0, 0)
+import qualified Data.Aeson.Key as Key
+#else
+import qualified Data.Text as T
+#endif
+
+#if MIN_VERSION_aeson(2, 0, 0)
+jsonKey :: String -> Key.Key
+jsonKey = Key.fromString
+#else
+jsonKey :: String -> T.Text
+jsonKey = T.pack
+#endif
+{-# INLINE jsonKey #-}
+
 
 -- | Sort a list of fields using merge sort, alias to 'FieldListSort'
 type Sort xs = FieldListSort xs
@@ -696,10 +711,10 @@ showRec :: forall lts. (RecApply lts lts (ConstC Show)) => Rec lts -> [(String, 
 showRec = reflectRec @(ConstC Show) (\(_ :: FldProxy lbl) v -> (symbolVal' (proxy# :: Proxy# lbl), show v))
 
 recToValue :: forall lts. (RecApply lts lts (ConstC ToJSON)) => Rec lts -> Value
-recToValue r = object $ reflectRec @(ConstC ToJSON) (\(_ :: FldProxy lbl) v -> (T.pack $ symbolVal' (proxy# :: Proxy# lbl), toJSON v)) r
+recToValue r = object $ reflectRec @(ConstC ToJSON) (\(_ :: FldProxy lbl) v -> (jsonKey $ symbolVal' (proxy# :: Proxy# lbl), toJSON v)) r
 
 recToEncoding :: forall lts. (RecApply lts lts (ConstC ToJSON)) => Rec lts -> Encoding
-recToEncoding r = pairs $ mconcat $ reflectRec @(ConstC ToJSON) (\(_ :: FldProxy lbl) v -> (T.pack (symbolVal' (proxy# :: Proxy# lbl)) .= v)) r
+recToEncoding r = pairs $ mconcat $ reflectRec @(ConstC ToJSON) (\(_ :: FldProxy lbl) v -> (jsonKey (symbolVal' (proxy# :: Proxy# lbl))) .= v) r
 
 recJsonParser :: forall lts s. (RecSize lts ~ s, KnownNat s, RecJsonParse lts) => Value -> Parser (Rec lts)
 recJsonParser =
@@ -762,7 +777,7 @@ instance TraversalCHelper bs as bs c => TraversalC c as bs where
 --
 -- Effects are performed in the same order as the fields.
 traverseC ::
-  forall c f as bs. ( TraversalC c as bs, Applicative f ) => 
+  forall c f as bs. ( TraversalC c as bs, Applicative f ) =>
   ( forall (l :: Symbol) a b. (KnownSymbol l, c l a b) => FldProxy l -> a -> f b ) -> Rec as -> f ( Rec bs )
 traverseC = traversalCHelper @bs @as @bs @c @f
 
@@ -835,7 +850,7 @@ instance
         do let lbl :: FldProxy l
                lbl = FldProxy
            rest <- recJsonParse initSize obj
-           (v :: t) <- obj .: T.pack (symbolVal lbl)
+           (v :: t) <- obj .: jsonKey (symbolVal lbl)
            pure $ unsafeRCons (lbl := v) rest
 
 -- | Conversion helper to bring a Haskell type to a record. Note that the

--- a/src/SuperRecord/Variant.hs
+++ b/src/SuperRecord/Variant.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE RoleAnnotations #-}
 {-# LANGUAGE UndecidableInstances #-}

--- a/src/SuperRecord/Variant.hs
+++ b/src/SuperRecord/Variant.hs
@@ -20,7 +20,7 @@ where
 import Control.Applicative
 import Control.DeepSeq
 import Data.Aeson
-import Data.Aeson.Types (Parser)
+import Data.Aeson.Types (Parser, parseFail)
 import Data.Maybe
 import Data.Proxy
 import GHC.Base (Any)
@@ -53,9 +53,8 @@ instance (ToJSON t, ToJSON (Variant ts)) => ToJSON (Variant (t ': ts)) where
         in fromMaybe (toJSON $ shrinkVariant v1) $ toJSON <$> w1
 
 instance FromJSON (Variant '[]) where
-    parseJSON r =
-        do () <- parseJSON r
-           pure emptyVariant
+    parseJSON _ =
+        parseFail "There is no JSON value devoid of a value, so no way to represent an emptyVariant"
 
 instance ( FromJSON t, FromJSON (Variant ts)
          ) => FromJSON (Variant (t ': ts)) where

--- a/src/SuperRecord/Variant.hs
+++ b/src/SuperRecord/Variant.hs
@@ -23,13 +23,14 @@ import Data.Aeson
 import Data.Aeson.Types (Parser, parseFail)
 import Data.Maybe
 import Data.Proxy
+import Data.Kind (Type)
 import GHC.Base (Any)
 import GHC.TypeLits
 import Unsafe.Coerce
 
 -- | A variant is used to express that a values type is of any of
 -- the types tracked in the type level list.
-data Variant (opts :: [*])
+data Variant (opts :: [Type])
     = Variant {-# UNPACK #-} !Word Any
 
 type role Variant representational

--- a/src/SuperRecord/Variant/Tagged.hs
+++ b/src/SuperRecord/Variant/Tagged.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE RoleAnnotations #-}
 {-# LANGUAGE UndecidableInstances #-}

--- a/src/SuperRecord/Variant/Tagged.hs
+++ b/src/SuperRecord/Variant/Tagged.hs
@@ -19,7 +19,7 @@ import SuperRecord.Variant
 
 import Control.Applicative
 import Data.Aeson
-import Data.Aeson.Types (Parser)
+import Data.Aeson.Types (Parser, parseFail)
 import Data.Maybe
 import GHC.TypeLits
 import qualified Data.Text as T
@@ -47,9 +47,8 @@ instance (KnownSymbol lbl, ToJSON t, ToJSON (JsonTaggedVariant ts)) => ToJSON (J
            in val
 
 instance FromJSON (JsonTaggedVariant '[]) where
-    parseJSON r =
-        do () <- parseJSON r
-           pure $ JsonTaggedVariant emptyVariant
+    parseJSON _ =
+        parseFail "There is no JSON value devoid of a value, so no way to represent an emptyVariant"
 
 instance ( FromJSON t, FromJSON (JsonTaggedVariant ts)
          , KnownSymbol lbl


### PR DESCRIPTION
This PR builds on #32, adding support for aeson 2.0 as well as GHC >= 9.0, but fixes some mistakes, gets the `Variant` code to work again and adds support for GHC 9.2.

* Support GHC >= 9.2 by using `Type` over `*`, also gets rid of the warnings for 9.0
* Support GHC >= 9.2 by adding `FlexibleContexts` where necessary
* Fix a long standing bug leading to a crash after a parse failure in the `FromJSON` for (tagged) `Variant`s. This bug hinges on `parseJSON x :: Parser ()` succeeding which is *always* the case for `aeson >= 2.0`, making this bug quite prevalent. See the commit message for further details.
* Adapt to aeson 2.0 API changes via CPP

| GHC | `aeson == 1.5.*` | `aeson == 2.0.*` |
|--------|-----------------------|-----------------------|
| 8.10.7 | works ✅ | works ✅ |
| 9.0.2 | works ✅ | works ✅ |
| 9.2.4 | no cabal install plan for `aeson-1.5.6.0` ❔ | works ✅ |