### PR TITLE
Change Show-instances to use `"#field := val"`

### DIFF
--- a/src/SuperRecord.hs
+++ b/src/SuperRecord.hs
@@ -86,7 +86,6 @@ import GHC.Generics
 import GHC.Exts
 import GHC.TypeLits
 import qualified Control.Monad.State as S
-import qualified Data.Text as T
 import Data.Semigroup as Sem (Semigroup(..))
 
 #ifdef JS_RECORD
@@ -97,6 +96,22 @@ import qualified JavaScript.Object.Internal as JS
 #else
 import GHC.ST ( ST(..) , runST)
 #endif
+
+#if MIN_VERSION_aeson(2, 0, 0)
+import qualified Data.Aeson.Key as Key
+#else
+import qualified Data.Text as T
+#endif
+
+#if MIN_VERSION_aeson(2, 0, 0)
+jsonKey :: String -> Key.Key
+jsonKey = Key.fromString
+#else
+jsonKey :: String -> T.Text
+jsonKey = T.pack
+#endif
+{-# INLINE jsonKey #-}
+
 
 -- | Sort a list of fields using merge sort, alias to 'FieldListSort'
 type Sort xs = FieldListSort xs
@@ -696,10 +711,10 @@ showRec :: forall lts. (RecApply lts lts (ConstC Show)) => Rec lts -> [(String, 
 showRec = reflectRec @(ConstC Show) (\(_ :: FldProxy lbl) v -> (symbolVal' (proxy# :: Proxy# lbl), show v))
 
 recToValue :: forall lts. (RecApply lts lts (ConstC ToJSON)) => Rec lts -> Value
-recToValue r = object $ reflectRec @(ConstC ToJSON) (\(_ :: FldProxy lbl) v -> (T.pack $ symbolVal' (proxy# :: Proxy# lbl), toJSON v)) r
+recToValue r = object $ reflectRec @(ConstC ToJSON) (\(_ :: FldProxy lbl) v -> (jsonKey $ symbolVal' (proxy# :: Proxy# lbl), toJSON v)) r
 
 recToEncoding :: forall lts. (RecApply lts lts (ConstC ToJSON)) => Rec lts -> Encoding
-recToEncoding r = pairs $ mconcat $ reflectRec @(ConstC ToJSON) (\(_ :: FldProxy lbl) v -> (T.pack (symbolVal' (proxy# :: Proxy# lbl)) .= v)) r
+recToEncoding r = pairs $ mconcat $ reflectRec @(ConstC ToJSON) (\(_ :: FldProxy lbl) v -> (jsonKey (symbolVal' (proxy# :: Proxy# lbl))) .= v) r
 
 recJsonParser :: forall lts s. (RecSize lts ~ s, KnownNat s, RecJsonParse lts) => Value -> Parser (Rec lts)
 recJsonParser =
@@ -762,7 +777,7 @@ instance TraversalCHelper bs as bs c => TraversalC c as bs where
 --
 -- Effects are performed in the same order as the fields.
 traverseC ::
-  forall c f as bs. ( TraversalC c as bs, Applicative f ) => 
+  forall c f as bs. ( TraversalC c as bs, Applicative f ) =>
   ( forall (l :: Symbol) a b. (KnownSymbol l, c l a b) => FldProxy l -> a -> f b ) -> Rec as -> f ( Rec bs )
 traverseC = traversalCHelper @bs @as @bs @c @f
 
@@ -835,7 +850,7 @@ instance
         do let lbl :: FldProxy l
                lbl = FldProxy
            rest <- recJsonParse initSize obj
-           (v :: t) <- obj .: T.pack (symbolVal lbl)
+           (v :: t) <- obj .: jsonKey (symbolVal lbl)
            pure $ unsafeRCons (lbl := v) rest
 
 -- | Conversion helper to bring a Haskell type to a record. Note that the

--- a/src/SuperRecord/Field.hs
+++ b/src/SuperRecord/Field.hs
@@ -29,8 +29,12 @@ instance (Ord value) => Ord (label := value) where
 
 instance (Show t) =>
          Show (l := t) where
-  showsPrec p (l := t) =
-      showParen (p > 10) (showString ("#" ++ symbolVal l ++ " := " ++ show t))
+  showsPrec d (l := t) =
+      showParen (d > labelPrec) $
+        showString ("#" ++ symbolVal l ++ " := ")
+        . showsPrec (labelPrec+1) t
+    where
+      labelPrec = 6
 
 -- | A proxy witness for a label. Very similar to 'Proxy', but needed to implement
 -- a non-orphan 'IsLabel' instance

--- a/src/SuperRecord/Variant.hs
+++ b/src/SuperRecord/Variant.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE RoleAnnotations #-}
 {-# LANGUAGE UndecidableInstances #-}

--- a/src/SuperRecord/Variant.hs
+++ b/src/SuperRecord/Variant.hs
@@ -20,7 +20,7 @@ where
 import Control.Applicative
 import Control.DeepSeq
 import Data.Aeson
-import Data.Aeson.Types (Parser)
+import Data.Aeson.Types (Parser, parseFail)
 import Data.Maybe
 import Data.Proxy
 import GHC.Base (Any)
@@ -53,9 +53,8 @@ instance (ToJSON t, ToJSON (Variant ts)) => ToJSON (Variant (t ': ts)) where
         in fromMaybe (toJSON $ shrinkVariant v1) $ toJSON <$> w1
 
 instance FromJSON (Variant '[]) where
-    parseJSON r =
-        do () <- parseJSON r
-           pure emptyVariant
+    parseJSON _ =
+        parseFail "There is no JSON value devoid of a value, so no way to represent an emptyVariant"
 
 instance ( FromJSON t, FromJSON (Variant ts)
          ) => FromJSON (Variant (t ': ts)) where

--- a/src/SuperRecord/Variant.hs
+++ b/src/SuperRecord/Variant.hs
@@ -23,13 +23,14 @@ import Data.Aeson
 import Data.Aeson.Types (Parser, parseFail)
 import Data.Maybe
 import Data.Proxy
+import Data.Kind (Type)
 import GHC.Base (Any)
 import GHC.TypeLits
 import Unsafe.Coerce
 
 -- | A variant is used to express that a values type is of any of
 -- the types tracked in the type level list.
-data Variant (opts :: [*])
+data Variant (opts :: [Type])
     = Variant {-# UNPACK #-} !Word Any
 
 type role Variant representational

--- a/src/SuperRecord/Variant/Tagged.hs
+++ b/src/SuperRecord/Variant/Tagged.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE RoleAnnotations #-}
 {-# LANGUAGE UndecidableInstances #-}

--- a/src/SuperRecord/Variant/Tagged.hs
+++ b/src/SuperRecord/Variant/Tagged.hs
@@ -19,7 +19,7 @@ import SuperRecord.Variant
 
 import Control.Applicative
 import Data.Aeson
-import Data.Aeson.Types (Parser)
+import Data.Aeson.Types (Parser, parseFail)
 import Data.Maybe
 import GHC.TypeLits
 import qualified Data.Text as T
@@ -47,9 +47,8 @@ instance (KnownSymbol lbl, ToJSON t, ToJSON (JsonTaggedVariant ts)) => ToJSON (J
            in val
 
 instance FromJSON (JsonTaggedVariant '[]) where
-    parseJSON r =
-        do () <- parseJSON r
-           pure $ JsonTaggedVariant emptyVariant
+    parseJSON _ =
+        parseFail "There is no JSON value devoid of a value, so no way to represent an emptyVariant"
 
 instance ( FromJSON t, FromJSON (JsonTaggedVariant ts)
          , KnownSymbol lbl

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -351,7 +351,7 @@ recordTests =
            do let vals = showRec r1
               vals `shouldBe` [("foo", "\"Hi\""), ("int", "213")]
        it "show works" $
-           show r1 `shouldBe` "[(\"foo\",\"\\\"Hi\\\"\"),(\"int\",\"213\")]"
+           show r1 `shouldBe` "[#foo := \"Hi\",#int := 213]"
        it "equality works" $
            do r1 == r1 `shouldBe` True
               r1 == set #foo "Hai" r1 `shouldBe` False


### PR DESCRIPTION
The previous show instance would add another layer of quoting for each
nesting:

```haskell
ghci> show (rcons (#foo := "bar") rnil)
"[(\"foo\",\"\\\"bar\\\"\")]"
```

Instead, what we want is to display a nicely readable variant of the
record, using the infix field syntax for both label/value pairs and
full records:

```haskell
ghci> show (rcons (#hi := (rcons (#lea := "hi") rnil)) (rcons (#foo := "bar") rnil ))
"[#foo := \"bar\",#hi := [(#lea := \"hi\")]]"

ghci> show (#hi := "lea")
"#hi := \"lea\""
```

That’s better!

Note that we can’t have a roundtripping `Read` instance anyway, so we
might as well have `Show` be readable.

Fixes https://github.com/agrafix/superrecord/issues/36

This includes the changes from #35